### PR TITLE
Feature: Add limitation to delete only owned posts

### DIFF
--- a/src/pages/post/[post].tsx
+++ b/src/pages/post/[post].tsx
@@ -86,12 +86,12 @@ const Post: NextPage = () => {
     <SCPostContent>
       {showModal && (
         <Modal
-          text='Are you sure about deleting the post?'
+          title='Delete Post'
+          text={`Are you sure about deleting your post?`}
           onCancel={handleCloseModal}
           onSubmit={handleDeletePost}
         />
       )}
-
       <SCAuthorContainer>
         <SCAuthorName>
           Author: {author ? author.name : 'Old legacy'}
@@ -105,7 +105,9 @@ const Post: NextPage = () => {
       <SCPostText>{post?.text}</SCPostText>
       <SCDeleteButtonContainer>
         <Button onClick={onBackButtonClick} text='Back' variant='secondary' />
-        <Button onClick={onDeletePost} text='Delete post' variant='danger' />
+        {isUserPost && (
+          <Button onClick={onDeletePost} text='Delete post' variant='danger' />
+        )}
       </SCDeleteButtonContainer>
     </SCPostContent>
   )


### PR DESCRIPTION
## What's new?

- Add validation to show `delete` button only if the posts is owned by the user. 

## Screenshots

- Before
<img width="904" alt="image" src="https://user-images.githubusercontent.com/40377128/204150366-3d05ff9e-8868-4f15-94c0-f34f1f673a3f.png">

- After
<img width="890" alt="image" src="https://user-images.githubusercontent.com/40377128/204150343-42c6fec2-2302-4a8a-b97c-68c50b00a634.png">

## Checklist
- [x] My branch respects our naming convention.
- [x] I've checked my code before the creation of this PR.
- [ ] I've made the test cases for the new implementation.
