### PR TITLE
feat: add alert when creating a post

### DIFF
--- a/src/components/Alert/Alert.spec.tsx
+++ b/src/components/Alert/Alert.spec.tsx
@@ -3,7 +3,11 @@ import { render } from '@testing-library/react'
 // Components
 import { Plus } from '../../icons/Plus'
 import { Alert } from './Alert'
+
+// Constants
 import { DANGER_COLOR } from '../../styles/constants'
+
+// Utils
 import { rgba2hex } from '../../utils/utils'
 
 const setup = (mock = {}) => render(<Alert text="We were on a break!!!" {...mock} />)

--- a/src/components/Dashboard/Dashboard.tsx
+++ b/src/components/Dashboard/Dashboard.tsx
@@ -36,6 +36,8 @@ import { getData } from './utils'
 
 // Context
 import { AlertContext } from '../../context/AlertContext/AlertContext'
+
+// Components
 import { Alert } from '../Alert/Alert'
 
 export const Dashboard: NextComponentType<NextPageContext> = () => {

--- a/src/components/Post/hooks/usePost.ts
+++ b/src/components/Post/hooks/usePost.ts
@@ -5,10 +5,11 @@ import axios from 'axios'
 import { useRouter } from 'next/router'
 // Types
 import { IPosts } from '../../PostPreviews/types'
+import { IAlertContext } from '../../../context/AlertContext/AlertContext.interface'
 // Constants
 import { HOME_PATH } from '../../../utils/contants'
+// Context
 import { AlertContext } from '../../../context/AlertContext/AlertContext'
-import { IAlertContext } from '../../../context/AlertContext/AlertContext.interface'
 
 export const usePost = () => {
   const [post, setPost] = useState<IPosts>()

--- a/src/context/AlertContext/AlertContext.interface.ts
+++ b/src/context/AlertContext/AlertContext.interface.ts
@@ -1,4 +1,5 @@
 import { ReactElement } from 'react'
+// Types
 import { IconsProps } from '../../icons/icons.interface'
 
 type AlertVariant = 'primary' | 'secundary' | 'danger' | null

--- a/src/context/AlertContext/AlertContext.spec.tsx
+++ b/src/context/AlertContext/AlertContext.spec.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render } from '@testing-library/react'
 import { useContext } from 'react'
+// Context
 import AlertContextProvider, { AlertContext } from './AlertContext'
+// Types
 import { IAlertContext } from './AlertContext.interface'
 
 jest.useFakeTimers()

--- a/src/pages/new/create-post.tsx
+++ b/src/pages/new/create-post.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 
 // Types
@@ -17,16 +17,18 @@ import { AUTHENTICATED, GITHUB_SIGN_IN, HOME_PATH } from 'src/utils/contants'
 import { Button } from '../../components/Button/Button'
 import { Input } from '../../components/Input/Input'
 import { Textarea } from '../../components/Textarea/Textarea'
-
 // Styles
 import { SCNewPostContainer, SCButtonArea } from '../../styles/create-post/styles'
+// Context
+import { AlertContext } from '../../context/AlertContext/AlertContext'
+import { IAlertContext } from '../../context/AlertContext/AlertContext.interface'
 
 const CreatePost: NextPage = () => {
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const router = useRouter()
   const [title, setTitle] = useState('')
   const [description, setDescription] = useState('')
-
+  const { setAlertInfo } = useContext(AlertContext)
   const { status, data: userData } = useSession()
 
   useEffect(() => {
@@ -61,15 +63,24 @@ const CreatePost: NextPage = () => {
       const newPostIsCreated = await createNewPost(post)
 
       if (newPostIsCreated) {
-        // TODO: Create a better alert
-        alert('se creó el post con éxito')
+        setAlertInfo((prev: IAlertContext) => ({
+          ...prev,
+          show: true,
+          variant: 'primary',
+          text: 'The post has been created succesfully',
+        }))
       }
 
       setTitle('')
       setDescription('')
       router.push('/')
     } else {
-      alert('error')
+      setAlertInfo((prev: IAlertContext) => ({
+        ...prev,
+        show: true,
+        variant: 'danger',
+        text: 'Something wrong happened',
+      }))
     }
   }
 


### PR DESCRIPTION
## What's new?

- Add snackbar alert when creating a post, replacing the old alert from navigator. 

## Screenshots

- Before
<img width="618" alt="image" src="https://user-images.githubusercontent.com/40377128/212587433-de0e0465-fab5-465a-98dd-1f0d6e69f6d3.png">


- After
<img width="1135" alt="image" src="https://user-images.githubusercontent.com/40377128/212587311-a879ce2f-9c3f-4d30-b449-fb0b72045571.png">


## Checklist
- [x] My branch respects our naming convention.
- [x] I've checked my code before the creation of this PR.
- [ ] I've made the test cases for the new implementation.
